### PR TITLE
Ft agent update advert api 166858175

### DIFF
--- a/server/middleware/validation.js
+++ b/server/middleware/validation.js
@@ -84,7 +84,49 @@ class Validations {
           .required()
           .error(() => 'State is a required field with a min of 3 chars and no special chars'),
 
-        city: Joi.string().min(5).max(15).required()
+        city: Joi.string().min(5).max(15).alphanum()
+          .required()
+          .error(() => 'City is a required field with a min of 3 chars and no special chars or numbers'),
+
+        price: Joi.number().required()
+          .error(() => 'Price is a required field with no special chars or alphabets'),
+
+        address: Joi.string().min(5).max(15).alphanum()
+          .required()
+          .error(() => 'Address is a required field with a min of 3 chars and no special chars or numbers'),
+
+        image_url: Joi.string().uri()
+          .required()
+          .error(() => 'Image_Url is a required field and no special chars or numbers'),
+
+      };
+      const { error } = Joi.validate(req.body, schema);
+
+      if (error) {
+        return res.status(400)
+          .json({
+            status: 'error',
+            data: error.details[0].message,
+          });
+      }
+      next();
+    } catch (e) {
+      console.log(e);
+    }
+  }
+
+  static async validateUpdateProperty(req, res, next) {
+    try {
+      const schema = {
+        type: Joi.string().min(5).max(15).required()
+          .error(() => 'Type is a required field with a min of 3 chars'),
+
+        state: Joi.string().min(5).max(15).alphanum()
+          .required()
+          .error(() => 'State is a required field with a min of 3 chars and no special chars'),
+
+        city: Joi.string().min(5).max(15).alphanum()
+          .required()
           .error(() => 'City is a required field with a min of 3 chars and no special chars or numbers'),
 
         price: Joi.number().required()

--- a/server/models/propertyModel.js
+++ b/server/models/propertyModel.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 import db from '../db/adverts';
 
 class PropertyModel {
@@ -6,7 +7,7 @@ class PropertyModel {
     this.result = null;
   }
 
-  async registerProperty() {
+  async createProperty() {
     const property = {
       _id: this.payload._id,
       owner: this.payload.owner,
@@ -21,6 +22,27 @@ class PropertyModel {
     };
     db.push(property);
     this.result = property;
+    return true;
+  }
+
+  async updateProperty() {
+    const obj = db.find(o => o._id === parseInt(this.payload._id));
+    if (!obj) {
+      return false;
+    }
+    const newAdvert = {
+      _id: obj._id,
+      owner: obj.owner,
+      status: obj.status,
+      type: this.payload.type,
+      state: this.payload.state,
+      city: this.payload.city,
+      price: this.payload.price,
+      address: this.payload.address,
+      image_url: this.payload.image_url,
+    };
+    db.splice(obj._id - 1, 1, newAdvert);
+    this.result = newAdvert;
     return true;
   }
 }

--- a/server/routes/propertyRoutes.js
+++ b/server/routes/propertyRoutes.js
@@ -7,5 +7,6 @@ import agent from '../middleware/agent';
 const router = express.Router();
 
 router.post('/property', [auth, agent], Validation.validateProperty, Property.postProperty);
+router.patch('/property/:property_id', [auth, agent], Validation.validateUpdateProperty, Property.updateProperty);
 
 export default router;

--- a/server/tests/property.test.js
+++ b/server/tests/property.test.js
@@ -47,7 +47,7 @@ describe('/PROPERTY', () => {
           status: 'Available',
           price: 5000000,
           state: 'Nairobi',
-          city: 'Nairobi City',
+          city: 'Nairobi',
           address: 'Kenya',
           type: '2 bedroom',
           image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
@@ -67,7 +67,7 @@ describe('/PROPERTY', () => {
           status: 'Available',
           price: 5000000,
           state: 'Nairobi',
-          city: 'Nairobi City',
+          city: 'Nairobi',
           address: 'Kenya',
           type: '2 bedroom',
           image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
@@ -87,7 +87,7 @@ describe('/PROPERTY', () => {
           status: 'Available',
           price: 5000000,
           state: 'Nairobi',
-          city: 'Nairobi City',
+          city: 'Nairobi',
           address: 'Kenya',
           type: '2 bedroom',
           image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
@@ -107,7 +107,7 @@ describe('/PROPERTY', () => {
           status: '',
           price: 5000000,
           state: 'Nairobi',
-          city: 'Nairobi City',
+          city: 'Nairobi',
           address: 'Kenya',
           type: '2 bedroom',
           image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
@@ -127,7 +127,7 @@ describe('/PROPERTY', () => {
           status: 'Available',
           price: '',
           state: 'Nairobi',
-          city: 'Nairobi City',
+          city: 'Nairobi',
           address: 'Kenya',
           type: '2 bedroom',
           image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
@@ -147,7 +147,7 @@ describe('/PROPERTY', () => {
           status: 'Available',
           price: 5000000,
           state: '',
-          city: 'Nairobi City',
+          city: 'Nairobi',
           address: 'Kenya',
           type: '2 bedroom',
           image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
@@ -187,7 +187,7 @@ describe('/PROPERTY', () => {
           status: 'Available',
           price: 5000000,
           state: 'Nairobi',
-          city: 'Nairobi City',
+          city: 'Nairobi',
           address: '',
           type: '2 bedroom',
           image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
@@ -207,7 +207,7 @@ describe('/PROPERTY', () => {
           status: 'Available',
           price: 5000000,
           state: 'Nairobi',
-          city: 'Nairobi City',
+          city: 'Nairobi',
           address: 'Kenya',
           type: '',
           image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
@@ -227,7 +227,7 @@ describe('/PROPERTY', () => {
           status: 'Available',
           price: 5000000,
           state: 'Nairobi',
-          city: 'Nairobi City',
+          city: 'Nairobi',
           address: 'Kenya',
           type: '2 bedroom',
           image_url: '',
@@ -247,7 +247,7 @@ describe('/PROPERTY', () => {
           status: '12#fj',
           price: 5000000,
           state: 'Nairobi',
-          city: 'Nairobi City',
+          city: 'Nairobi',
           address: 'Kenya',
           type: '2 bedroom',
           image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
@@ -267,7 +267,7 @@ describe('/PROPERTY', () => {
           status: 'Available',
           price: 'a large mount',
           state: 'Nairobi',
-          city: 'Nairobi City',
+          city: 'Nairobi',
           address: 'Kenya',
           type: '2 bedroom',
           image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
@@ -287,7 +287,7 @@ describe('/PROPERTY', () => {
           status: 'Available',
           price: 5000000,
           state: '1234',
-          city: 'Nairobi City',
+          city: 'Nairobi',
           address: 'Kenya',
           type: '2 bedroom',
           image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
@@ -327,7 +327,7 @@ describe('/PROPERTY', () => {
           status: 'Available',
           price: 5000000,
           state: 'Nairobi',
-          city: 'Nairobi City',
+          city: 'Nairobi',
           address: '@#%%',
           type: '2 bedroom',
           image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
@@ -347,7 +347,7 @@ describe('/PROPERTY', () => {
           status: 'Available',
           price: 5000000,
           state: 'Nairobi',
-          city: 'Nairobi City',
+          city: 'Nairobi',
           address: '  Kenya',
           type: ' @#%@',
           image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
@@ -367,7 +367,7 @@ describe('/PROPERTY', () => {
           status: 'Available',
           price: 5000000,
           state: 'Nairobi',
-          city: 'Nairobi City',
+          city: 'Nairobi',
           address: 'Kenya',
           type: '2 bedroom',
           image_url: '@#%%',
@@ -381,12 +381,17 @@ describe('/PROPERTY', () => {
   });
 
   describe('/PATCH property', () => {
-    it('should successfully update price of property advert', (done) => {
+    it('should successfully update property advert', (done) => {
       chai.request(app)
         .patch('/api/v1/property/1')
         .set('authorization', `Bearer ${agentToken}`)
         .send({
           price: 6000000,
+          state: 'Nairobi',
+          city: 'Nairobi',
+          address: 'Kenya',
+          type: '2 bedroom',
+          image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
         })
         .end((err, res) => {
           res.should.have.status(200);
@@ -397,10 +402,15 @@ describe('/PROPERTY', () => {
 
     it('should not update a property advert with no token', (done) => {
       chai.request(app)
-        .post('/api/v1/property/1')
+        .patch('/api/v1/property/1')
         .set('authorization', ' ')
         .send({
-          rice: 6000000,
+          price: 6000000,
+          state: 'Nairobi',
+          city: 'Nairobi',
+          address: 'Kenya',
+          type: '2 bedroom',
+          image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
         })
         .end((err, res) => {
           res.should.have.status(401);
@@ -409,12 +419,17 @@ describe('/PROPERTY', () => {
         });
     });
 
-    it('should not update a property advert with invalid token', (done) => {
+    it('should not update a property advert with forbidden token', (done) => {
       chai.request(app)
-        .post('/api/v1/property/1')
+        .patch('/api/v1/property/1')
         .set('authorization', `Bearer ${userToken}`)
         .send({
           price: 6000000,
+          state: 'Nairobi',
+          city: 'Nairobi',
+          address: 'Kenya',
+          type: '2 bedroom',
+          image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
         })
         .end((err, res) => {
           res.should.have.status(403);
@@ -425,10 +440,15 @@ describe('/PROPERTY', () => {
 
     it('should not update a property advert if no id exists', (done) => {
       chai.request(app)
-        .post('/api/v1/property/100')
-        .set('authorization', `Bearer ${userToken}`)
+        .patch('/api/v1/property/111')
+        .set('authorization', `Bearer ${agentToken}`)
         .send({
           price: 6000000,
+          state: 'Nairobi',
+          city: 'Nairobi',
+          address: 'Kenya',
+          type: '2 bedroom',
+          image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
         })
         .end((err, res) => {
           res.should.have.status(404);
@@ -437,71 +457,229 @@ describe('/PROPERTY', () => {
         });
     });
 
-    it('should successfully update state of property advert', (done) => {
+    it('should not update advert with invalid price', (done) => {
       chai.request(app)
-        .post('/api/v1/property/1')
+        .patch('/api/v1/property/1')
         .set('authorization', `Bearer ${agentToken}`)
         .send({
-          state: 'Kisumu',
-        })
-        .end((err, res) => {
-          res.should.have.status(200);
-          if (err) return done();
-          done();
-        });
-    });
-
-    it('should successfully update city of property advert', (done) => {
-      chai.request(app)
-        .post('/api/v1/property/1')
-        .set('authorization', `Bearer ${agentToken}`)
-        .send({
-          city: 'Kisumu City',
-        })
-        .end((err, res) => {
-          res.should.have.status(200);
-          if (err) return done();
-          done();
-        });
-    });
-
-    it('should successfully update address of property advert', (done) => {
-      chai.request(app)
-        .post('/api/v1/property/1')
-        .set('authorization', `Bearer ${agentToken}`)
-        .send({
-          address: 'Rwanda',
-        })
-        .end((err, res) => {
-          res.should.have.status(200);
-          if (err) return done();
-          done();
-        });
-    });
-
-    it('should successfully update address of type advert', (done) => {
-      chai.request(app)
-        .post('/api/v1/property/1')
-        .set('authorization', `Bearer ${agentToken}`)
-        .send({
-          type: '3 bedroom',
-        })
-        .end((err, res) => {
-          res.should.have.status(200);
-          if (err) return done();
-          done();
-        });
-    });
-
-    it('should successfully update image_url of type advert', (done) => {
-      chai.request(app)
-        .post('/api/v1/property/1')
-        .set('authorization', `Bearer ${agentToken}`)
-        .send({
+          price: 'yazaa',
+          state: 'Nairobi',
+          city: 'Nairobi',
+          address: 'Kenya',
+          type: '2 bedroom',
           image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
         })
         .end((err, res) => {
-          res.should.have.status(200);
+          res.should.have.status(400);
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not update advert with invalid state', (done) => {
+      chai.request(app)
+        .patch('/api/v1/property/1')
+        .set('authorization', `Bearer ${agentToken}`)
+        .send({
+          price: 6000000,
+          state: 'Nai@robi',
+          city: 'Nairobi',
+          address: 'Kenya',
+          type: '2 bedroom',
+          image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
+        })
+        .end((err, res) => {
+          res.should.have.status(400);
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not update advert with invalid city', (done) => {
+      chai.request(app)
+        .patch('/api/v1/property/1')
+        .set('authorization', `Bearer ${agentToken}`)
+        .send({
+          price: 6000000,
+          state: 'Nairobi',
+          city: 'N@irobi',
+          address: 'Kenya',
+          type: '2 bedroom',
+          image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
+        })
+        .end((err, res) => {
+          res.should.have.status(400);
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not update advert with invalid address', (done) => {
+      chai.request(app)
+        .patch('/api/v1/property/1')
+        .set('authorization', `Bearer ${agentToken}`)
+        .send({
+          price: 6000000,
+          state: 'Nairobi',
+          city: 'Nairobi',
+          address: 'Keny@',
+          type: '2 bedroom',
+          image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
+        })
+        .end((err, res) => {
+          res.should.have.status(400);
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not update advert with invalid type', (done) => {
+      chai.request(app)
+        .patch('/api/v1/property/1')
+        .set('authorization', `Bearer ${agentToken}`)
+        .send({
+          price: 6000000,
+          state: 'Nairobi',
+          city: 'Nairobi',
+          address: 'Kenya',
+          type: '1Rm',
+          image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
+        })
+        .end((err, res) => {
+          res.should.have.status(400);
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not update advert with invalid image_url', (done) => {
+      chai.request(app)
+        .patch('/api/v1/property/1')
+        .set('authorization', `Bearer ${agentToken}`)
+        .send({
+          price: 6000000,
+          state: 'Nairobi',
+          city: 'Nairobi',
+          address: 'Kenya',
+          type: '2 bedroom',
+          image_url: 'kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
+        })
+        .end((err, res) => {
+          res.should.have.status(400);
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not update advert with missing price', (done) => {
+      chai.request(app)
+        .patch('/api/v1/property/1')
+        .set('authorization', `Bearer ${agentToken}`)
+        .send({
+          price: '',
+          state: 'Nairobi',
+          city: 'Nairobi',
+          address: 'Kenya',
+          type: '2 bedroom',
+          image_url: 'kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
+        })
+        .end((err, res) => {
+          res.should.have.status(400);
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not update advert with missing state', (done) => {
+      chai.request(app)
+        .patch('/api/v1/property/1')
+        .set('authorization', `Bearer ${agentToken}`)
+        .send({
+          price: 6000000,
+          state: '',
+          city: 'Nairobi',
+          address: 'Kenya',
+          type: '2 bedroom',
+          image_url: 'kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
+        })
+        .end((err, res) => {
+          res.should.have.status(400);
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not update advert with missing city', (done) => {
+      chai.request(app)
+        .patch('/api/v1/property/1')
+        .set('authorization', `Bearer ${agentToken}`)
+        .send({
+          price: 6000000,
+          state: 'Nairobi',
+          city: '',
+          address: 'Kenya',
+          type: '2 bedroom',
+          image_url: 'kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
+        })
+        .end((err, res) => {
+          res.should.have.status(400);
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not update advert with missing address', (done) => {
+      chai.request(app)
+        .patch('/api/v1/property/1')
+        .set('authorization', `Bearer ${agentToken}`)
+        .send({
+          price: 6000000,
+          state: 'Nairobi',
+          city: 'Nairobi',
+          address: '',
+          type: '2 bedroom',
+          image_url: 'kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
+        })
+        .end((err, res) => {
+          res.should.have.status(400);
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not update advert with missing type', (done) => {
+      chai.request(app)
+        .patch('/api/v1/property/1')
+        .set('authorization', `Bearer ${agentToken}`)
+        .send({
+          price: 6000000,
+          state: 'Nairobi',
+          city: 'Nairobi',
+          address: 'Kenya',
+          type: '2 bedroom',
+          image_url: 'kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
+        })
+        .end((err, res) => {
+          res.should.have.status(400);
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not update advert with missing image_url', (done) => {
+      chai.request(app)
+        .patch('/api/v1/property/1')
+        .set('authorization', `Bearer ${agentToken}`)
+        .send({
+          price: 6000000,
+          state: 'Nairobi',
+          city: 'Nairobi',
+          address: 'Kenya',
+          type: '2 bedroom',
+          image_url: '',
+        })
+        .end((err, res) => {
+          res.should.have.status(400);
           if (err) return done();
           done();
         });


### PR DESCRIPTION
#### What does this PR do?
Enable an Agent to update their advert
#### Description of Task to be completed?
* create an update method in models
* create an update advert controller
* Add update property route and protect the route
* tests should pass
#### How should this be manually tested?
CLONE this repo
CD into it
run `npm test`
Tests should pass

using postman visit the route:
PATCH http://127.0.0.1:5000/api/v1/property/1
with A VALID TOKEN.Edit any value in the property advert.The response should contain your updated property.
```
{
    "status": "success",
    "data": {
        "_id": 2,
        "owner": "1",
        "status": "Available",
        "price": 10000000,
        "state": "Western",
        "city": "Kakamega",
        "address": "Kenya",
        "type": "2 bedroom",
        "image_url": "https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png"
    }
}
```
#### What are the relevant pivotal tracker stories?
#166858175
#### Screenshots (if appropriate)
![Update_Advert](https://user-images.githubusercontent.com/45785786/60456331-b2517180-9c41-11e9-82e8-f333356f48de.png)
![update_advert_tests_passing](https://user-images.githubusercontent.com/45785786/60456334-b5e4f880-9c41-11e9-9693-4cdb3e3149d9.png)

