### PR TITLE
Ft agent mark advert sold 166860175

### DIFF
--- a/server/controllers/propertyEndpoints.js
+++ b/server/controllers/propertyEndpoints.js
@@ -95,6 +95,36 @@ class Property {
       res.status(500);
     }
   }
+
+  static async markSold(req, res){
+    try{
+      const token = req.headers.authorization.split(' ')[1];
+      const decoded = jwt.verify(token, process.env.JWT_KEY);
+
+      const user_id = decoded._id
+
+      const _id = req.params.property_id;
+
+      const property = new PropertyModel({
+        _id
+      });
+
+      if (!await property.markProperty() || (user_id !== property.result.owner)) {
+        return res.status(404)
+          .json({
+            status: 'Error',
+            data: 'You have no advert with that Id',
+          });
+      } return res.status(200)
+        .json({
+          status: 'Success',
+          data: property.result,
+        });
+    }catch{
+      console.log(e);
+      res.status(500);
+    }
+  }
 }
 
 export default Property;

--- a/server/models/propertyModel.js
+++ b/server/models/propertyModel.js
@@ -45,6 +45,27 @@ class PropertyModel {
     this.result = newAdvert;
     return true;
   }
+
+  async markProperty() {
+    const obj = db.find(o => o._id === parseInt(this.payload._id));
+    if (!obj) {
+      return false;
+    }
+    const newAdvert = {
+      _id: obj._id,
+      owner: obj.owner,
+      status: 'Sold',
+      type: obj.type,
+      state: obj.state,
+      city: obj.city,
+      price: obj.price,
+      address: obj.address,
+      image_url: obj.image_url,
+    };
+    db.splice(obj._id - 1, 1, newAdvert);
+    this.result = newAdvert;
+    return true;
+  }
 }
 
 export default PropertyModel;

--- a/server/routes/propertyRoutes.js
+++ b/server/routes/propertyRoutes.js
@@ -8,5 +8,6 @@ const router = express.Router();
 
 router.post('/property', [auth, agent], Validation.validateProperty, Property.postProperty);
 router.patch('/property/:property_id', [auth, agent], Validation.validateUpdateProperty, Property.updateProperty);
+router.patch('/property/:property_id/sold', [auth, agent], Property.markSold);
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
Enable an Agent to mark their advert as sold
#### Description of Task to be completed?
* create an mark advert method in models
* create an mark advertcontroller
* Add mark advert route and protect the route
* tests should pass
#### How should this be manually tested?
CLONE this repo
CD into it
run `npm test`
Tests should pass

using postman visit the route:
PATCH http://127.0.0.1:5000/api/v1/property/:<property_id>/sold
with A VALID TOKEN.
The status should change to SOLD.
```
{
    "status": "success",
    "data": {
        "_id": 2,
        "owner": "1",
        "status": "sold",
        "price": 10000000,
        "state": "Western",
        "city": "Kakamega",
        "address": "Kenya",
        "type": "2 bedroom",
        "image_url": "https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png"
    }
}
```
#### What are the relevant pivotal tracker stories?
#166860175
#### Screenshots (if appropriate)
![SOLD-PASSING](https://user-images.githubusercontent.com/45785786/60460893-a8ce0680-9c4d-11e9-938e-7d5b85a26da8.png)
![SOLD](https://user-images.githubusercontent.com/45785786/60460906-b1bed800-9c4d-11e9-8ec9-0ba0d6b564a1.png)

