### PR TITLE
Ft agent delete advert 166860177

### DIFF
--- a/server/controllers/propertyEndpoints.js
+++ b/server/controllers/propertyEndpoints.js
@@ -96,17 +96,17 @@ class Property {
     }
   }
 
-  static async markSold(req, res){
-    try{
+  static async markSold(req, res) {
+    try {
       const token = req.headers.authorization.split(' ')[1];
       const decoded = jwt.verify(token, process.env.JWT_KEY);
 
-      const user_id = decoded._id
+      const user_id = decoded._id;
 
       const _id = req.params.property_id;
 
       const property = new PropertyModel({
-        _id
+        _id,
       });
 
       if (!await property.markProperty() || (user_id !== property.result.owner)) {
@@ -120,7 +120,37 @@ class Property {
           status: 'Success',
           data: property.result,
         });
-    }catch{
+    } catch (e) {
+      console.log(e);
+      res.status(500);
+    }
+  }
+
+  static async deleteAdvert(req, res) {
+    try {
+      const token = req.headers.authorization.split(' ')[1];
+      const decoded = jwt.verify(token, process.env.JWT_KEY);
+
+      const user_id = decoded._id;
+
+      const _id = req.params.property_id;
+
+      const property = new PropertyModel({
+        _id,
+      });
+
+      if (!await property.delete() || (user_id !== property.result.owner)) {
+        return res.status(404)
+          .json({
+            status: 'Error',
+            data: 'You have no advert with that Id',
+          });
+      } return res.status(200)
+        .json({
+          status: 'Success',
+          data: 'successfully deleted ',
+        });
+    } catch (e) {
       console.log(e);
       res.status(500);
     }

--- a/server/models/propertyModel.js
+++ b/server/models/propertyModel.js
@@ -66,6 +66,16 @@ class PropertyModel {
     this.result = newAdvert;
     return true;
   }
+
+  async delete() {
+    const obj = db.find(o => o._id === parseInt(this.payload._id));
+    if (!obj) {
+      return false;
+    }
+    this.result = obj;
+    db.splice(db.indexOf(obj), 1);
+    return true;
+  }
 }
 
 export default PropertyModel;

--- a/server/routes/propertyRoutes.js
+++ b/server/routes/propertyRoutes.js
@@ -9,5 +9,6 @@ const router = express.Router();
 router.post('/property', [auth, agent], Validation.validateProperty, Property.postProperty);
 router.patch('/property/:property_id', [auth, agent], Validation.validateUpdateProperty, Property.updateProperty);
 router.patch('/property/:property_id/sold', [auth, agent], Property.markSold);
+router.delete('/property/:property_id', [auth, agent], Property.deleteAdvert);
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
An agent should be able to delete their advert
#### Description of Task to be completed?
* create delete method in property models
* create a deleteproperty mmethod in  property controller
* add the controller to the routes with relevant permissions
* Tests should pass
#### How should this be manually tested?
CLONE this repo
CD into it
run `npm test`
Tests should pass

Visist the link in post man with a valid agent token:
PATCH `http://127.0.0.1:5000/api/v1/property/:</PROPERTY-ID>`
If the property exists the response should be:
```
{
    "status": "Success",
    "data": "Property successfully deleted"
}
```

#### What are the relevant pivotal tracker stories?
#166860177
#### Screenshots (if appropriate)
![passing delete](https://user-images.githubusercontent.com/45785786/60483518-6c76c680-9c9e-11e9-9b86-19365b911b42.png)
![delete_success](https://user-images.githubusercontent.com/45785786/60483570-a942bd80-9c9e-11e9-97ec-b45f9118a3ba.png)

