### PR TITLE
[#167221905] Fix JWT expiry and 500 errors by BurnerB

### DIFF
--- a/server/controllers/propertyEndpoints.js
+++ b/server/controllers/propertyEndpoints.js
@@ -11,7 +11,6 @@ import uploader from '../helpers/uploader';
 
 
 dotenv.config();
-
 const created_on = moment().format('MMMM Do YYYY, h:mm:ss a');
 
 class Property {

--- a/server/controllers/propertyEndpoints.js
+++ b/server/controllers/propertyEndpoints.js
@@ -31,6 +31,9 @@ class Property {
       const owner = req.user._id;
       const ownerEmail = req.user.email;
       const ownerPhoneNumber = req.user.phoneNumber;
+      if (!req.files) {
+        return response.handleError(400, 'Image should not be empty', res);
+      }
       const image = req.files.photo;
       if (process.env.NODE_ENV !== 'test') {
         image_url = await uploader(image);

--- a/server/helpers/jwt.js
+++ b/server/helpers/jwt.js
@@ -7,7 +7,7 @@ dotenv.config();
 class Token {
   static generateToken(payload) {
     const token = jwt.sign(payload, process.env.JWT_KEY, {
-      expiresIn: '1h',
+      expiresIn: '100d',
     });
     return token;
   }


### PR DESCRIPTION
#### What does this PR do?
Remove 500 error and set jwt expiry
#### Description of Task to be completed?
* Catch any error that returns 500
* Deal with invalid http request on postman
* Tokens should expire after 1 week
#### How should this be manually tested?
clone this repo
run the  endpoint on post man:
COPY `http://127.0.0.1:5000/api/v1/auth/signup`
You should recieve the endpoint:
```
"status": 404,
"error": "Invalid http request"
```
#### What are the relevant pivotal tracker stories?
[#167221905](https://www.pivotaltracker.com/story/show/167221905)
#### Screenshots (if appropriate)
![12234](https://user-images.githubusercontent.com/45785786/61060707-a3b64780-a403-11e9-9cf8-5c0dad2b07d6.png)
