### PR TITLE
[167271624] Fix updatedetails optional and jwt in response

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,14 +1,17 @@
 /* eslint-disable indent */
 import dotenv from 'dotenv';
 import express from 'express';
+import swaggerUi from 'swagger-ui-express';
 import '@babel/polyfill';
 import bodyParser from 'body-parser';
+import swaggerDocument from './swagger.json';
 import routes from './server/routes';
 import errorhandler from './server/helpers/errorhandler'
 import response from './server/helpers/responses';
 
 const app = express();
 const port = process.env.PORT || 5000;
+
 
 console.log(`NODE_ENV: ${process.env.NODE_ENV}`);
 console.log(`app: ${app.get('env')}`);
@@ -18,6 +21,12 @@ app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({
 	extended: true,
 }));
+
+let options = {
+    explorer: true
+  };
+   
+app.use('/api/v1/swagger', swaggerUi.serve, swaggerUi.setup(swaggerDocument, options));
 
 routes(app);
 dotenv.config();

--- a/app.js
+++ b/app.js
@@ -22,11 +22,11 @@ app.use(bodyParser.urlencoded({
 	extended: true,
 }));
 
-let options = {
-    explorer: true
-  };
+// let options = {
+//     explorer: true
+//   };
    
-app.use('/api/v1/swagger', swaggerUi.serve, swaggerUi.setup(swaggerDocument, options));
+// app.use('/api/v1/swagger', swaggerUi.serve, swaggerUi.setup(swaggerDocument, options));
 
 routes(app);
 dotenv.config();

--- a/server/controllers/authEndpoints.js
+++ b/server/controllers/authEndpoints.js
@@ -50,7 +50,7 @@ class Authentication {
       newUser.result["token"]=token;
       // console.log(newUser.result);
       return response.authsuccess(201, 'success',
-                                   _.pick(newUser.result,['_id','email', 'firstname','lastname','phoneNumber','address']), res);
+                                   _.pick(newUser.result,['_id','email', 'firstname','lastname','phoneNumber','address','token']), res);
     } catch (e) {
       return response.catchError(500, e.toString(), res);
     }
@@ -72,7 +72,7 @@ class Authentication {
             const token = Token.genToken(_id, email, firstname, lastname, is_Agent, is_Admin, phoneNumber);
             user.result["token"]=token;
             return response.authsuccess(200, 'success', 
-                                        _.pick(user.result,['_id','email', 'firstname','lastname','phoneNumber','address', 'is_Admin','is_Agent']), res);
+                                        _.pick(user.result,['_id','email', 'firstname','lastname','phoneNumber','address', 'is_Admin','is_Agent','token']), res);
         }
         return response.handleError(401, 'Incorrect password Email combination', res);
 

--- a/server/controllers/propertyEndpoints.js
+++ b/server/controllers/propertyEndpoints.js
@@ -89,7 +89,8 @@ class Property {
 
       if (!await property.updateProperty() || (user_id !== property.result.owner)) {
         return response.handleError(404, 'You have no advert with that Id', res);
-      } return response.handleSuccess(200, property.result, res);
+      }console.log(property.res) 
+      return response.handleSuccess(200, property.result, res);
     } catch (e) {
       return response.catchError(500, e.toString(), res);
     }

--- a/server/middleware/advertValidation.js
+++ b/server/middleware/advertValidation.js
@@ -41,21 +41,21 @@ class Validations {
   static async validateUpdateProperty(req, res, next) {
     try {
       const schema = {
-        type: Joi.string().min(5).max(15).required()
+        type: Joi.string().min(5).max(15).optional()
           .error(() => 'Type is a required field with a min of 3 chars and no special characters'),
 
         state: Joi.string().min(5).max(15).alphanum()
-          .required()
+          .optional()
           .error(() => 'State is a required field with a min of 3 chars and no special chars'),
 
         city: Joi.string().min(5).max(15).alphanum()
-          .required()
+          .optional()
           .error(() => 'City is a required field with a min of 3 chars and no special chars or numbers'),
 
-        price: Joi.number().required().error(() => 'Price is a required field with no special chars or alphabets'),
+        price: Joi.number().optional().error(() => 'Price is a required field with no special chars or alphabets'),
 
         address: Joi.string().min(5).max(15).alphanum()
-          .required()
+          .optional()
           .error(() => 'Address is a required field with a min of 3 chars and no special chars or numbers'),
       };
       const { error } = Joi.validate(req.body, schema);

--- a/server/models/propertyModel.js
+++ b/server/models/propertyModel.js
@@ -40,7 +40,7 @@ class PropertyModel {
       type: this.payload.type,
       state: this.payload.state,
       city: this.payload.city,
-      price: parseInt(this.payload.price),
+      price: obj.price,
       address: this.payload.address,
       image_url: this.payload.image_url,
       created_on: this.payload.created_on,


### PR DESCRIPTION
#### What does this PR do?
Fix user update advert and add jwt to responses
#### Description of Task to be completed?
* Fix user update property by making properties optional
* User login and signup should return tokens
#### How should this be manually tested?
clone this repo
run the  endpoint on post man:
POST `http://127.0.0.1:5000/api/v1/auth/signup`
You should recieve the response:
```
 "status": 201,
    "data": {
        "_id": 2,
        "email": "johndoe@gmail.com",
        "firstname": "john",
        "lastname": "doe",
        "phoneNumber": "0000000000",
        "address": "Kigali1123",
        "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJfaWQiOjIsImVtYWlsIjoiam9"
```
visit the  link  on postman:
PATCH http://127.0.0.1:5000/api/v1/property/1
With a request body of EITHER state,city,price or address
The created property should contain the updated value

#### What are the relevant pivotal tracker stories?
[#167271624](https://www.pivotaltracker.com/story/show/167271624)
#### Screenshots (if appropriate)
![TOOKEEEN](https://user-images.githubusercontent.com/45785786/61175413-7ad6b380-a5b7-11e9-9ef6-a89efa5d5dae.png)
![UPDATE PROPERTY](https://user-images.githubusercontent.com/45785786/61175414-7ca07700-a5b7-11e9-8aef-cc22c574e4f5.png)

