### PR TITLE
[167287845] Agent mark advert as sold

### DIFF
--- a/server/controllers/propertyEndpoints.js
+++ b/server/controllers/propertyEndpoints.js
@@ -98,15 +98,13 @@ class Property {
 
       const user_id = decoded._id;
 
-      const _id = req.params.property_id;
+      const id = req.params.property_id;
 
-      const property = new PropertyModel({
-        _id,
-      });
+      const property = await PropertyModel.markProperty(id)
 
-      if (!await property.markProperty() || (user_id !== property.result.owner)) {
+      if (!property  || (user_id !== property.owner)) {
         return response.handleError(404, 'You have no advert with that Id', res);
-      } return response.handleSuccess(200, property.result, res);
+      } return response.handleSuccess(200, property, res);
     } catch (e) {
       return response.catchError(500, e.toString(), res);
     }

--- a/server/models/propertyModel.js
+++ b/server/models/propertyModel.js
@@ -27,5 +27,26 @@ class PropertyModel {
     const user = foundUser.rows[0];
     return user;
   }
+
+  static async allproperties(){
+    const query = `SELECT * FROM properties`;
+    const adverts = await pool.query(query);
+    const allAdverts = adverts.rows[0];
+    return allAdverts;
+  }
+
+  static async updateProperty(id, price){
+    const query =`UPDATE properties SET price= $1 WHERE id = $2 RETURNING *`;
+    const Updates = [price,id];
+    const {rows} = await pool.query(query,Updates);
+    return rows[0];
+  }
+
+  static async markProperty(id) {
+    const query = 'UPDATE properties SET status = $1 WHERE id = $2 returning *';
+    const values = ['SOLD',id];
+    const { rows } = await pool.query(query,values)
+    return rows;
+  }
 }
 export default PropertyModel;

--- a/server/tests/property.test.js
+++ b/server/tests/property.test.js
@@ -326,374 +326,375 @@ describe('/PROPERTY', () => {
         });
     });
   });
+
+  describe('/PATCH property', () => {
+    it('should successfully update property advert', (done) => {
+      chai.request(app)
+        .patch('/api/v2/property/1')
+        .set('authorization', `Bearer ${agentToken}`)
+        .send({
+          price: 6000000,
+          state: 'Nairobi',
+          city: 'Nairobi',
+          address: 'Kenya',
+          type: '2 bedroom',
+        })
+        .end((err, res) => {
+          res.should.have.status(200);
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not update a property advert with no token', (done) => {
+      chai.request(app)
+        .patch('/api/v2/property/1')
+        .set('authorization', ' ')
+        .send({
+          price: 6000000,
+          state: 'Nairobi',
+          city: 'Nairobi',
+          address: 'Kenya',
+          type: '2 bedroom',
+          image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
+        })
+        .end((err, res) => {
+          res.should.have.status(401);
+          expect(res.body.error).equals('ACCESS DENIED! No token provided');
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not update a property advert with forbidden token', (done) => {
+      chai.request(app)
+        .patch('/api/v2/property/1')
+        .set('authorization', `Bearer ${userToken}`)
+        .send({
+          price: 6000000,
+          state: 'Nairobi',
+          city: 'Nairobi',
+          address: 'Kenya',
+          type: '2 bedroom',
+          image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
+        })
+        .end((err, res) => {
+          res.should.have.status(403);
+          expect(res.body.error).equals('ACCESS DENIED! Not an Agent');
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not update a property advert if no id exists', (done) => {
+      chai.request(app)
+        .patch('/api/v2/property/111')
+        .set('authorization', `Bearer ${agentToken}`)
+        .send({
+          price: 6000000,
+          state: 'Nairobi',
+          city: 'Nairobi',
+          address: 'Kenya',
+          type: '2 bedroom',
+        })
+        .end((err, res) => {
+          res.should.have.status(404);
+          expect(res.body.error).equals('You have no advert with that Id');
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not update advert with invalid price', (done) => {
+      chai.request(app)
+        .patch('/api/v2/property/1')
+        .set('authorization', `Bearer ${agentToken}`)
+        .send({
+          price: 'yazaa',
+          state: 'Nairobi',
+          city: 'Nairobi',
+          address: 'Kenya',
+          type: '2 bedroom',
+          image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
+        })
+        .end((err, res) => {
+          res.should.have.status(400);
+          expect(res.body.error).equals('Price is a required field with no special chars or alphabets');
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not update advert with invalid state', (done) => {
+      chai.request(app)
+        .patch('/api/v2/property/1')
+        .set('authorization', `Bearer ${agentToken}`)
+        .send({
+          price: 6000000,
+          state: 'Nai@robi',
+          city: 'Nairobi',
+          address: 'Kenya',
+          type: '2 bedroom',
+          image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
+        })
+        .end((err, res) => {
+          res.should.have.status(400);
+          expect(res.body.error).equals('State is a required field with a min of 3 chars and no special chars');
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not update advert with invalid city', (done) => {
+      chai.request(app)
+        .patch('/api/v2/property/1')
+        .set('authorization', `Bearer ${agentToken}`)
+        .send({
+          price: 6000000,
+          state: 'Nairobi',
+          city: 'N@irobi',
+          address: 'Kenya',
+          type: '2 bedroom',
+          image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
+        })
+        .end((err, res) => {
+          res.should.have.status(400);
+          expect(res.body.error).equals('City is a required field with a min of 3 chars and no special chars or numbers');
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not update advert with invalid address', (done) => {
+      chai.request(app)
+        .patch('/api/v2/property/1')
+        .set('authorization', `Bearer ${agentToken}`)
+        .send({
+          price: 6000000,
+          state: 'Nairobi',
+          city: 'Nairobi',
+          address: 'Keny@',
+          type: '2 bedroom',
+          image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
+        })
+        .end((err, res) => {
+          res.should.have.status(400);
+          expect(res.body.error).equals('Address is a required field with a min of 3 chars and no special chars or numbers');
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not update advert with invalid type', (done) => {
+      chai.request(app)
+        .patch('/api/v2/property/1')
+        .set('authorization', `Bearer ${agentToken}`)
+        .send({
+          price: 6000000,
+          state: 'Nairobi',
+          city: 'Nairobi',
+          address: 'Kenya',
+          type: '1Rm',
+          image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
+        })
+        .end((err, res) => {
+          res.should.have.status(400);
+          expect(res.body.error).equals('Type is a required field with a min of 3 chars and no special characters');
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not update advert with invalid image_url', (done) => {
+      chai.request(app)
+        .patch('/api/v2/property/1')
+        .set('authorization', `Bearer ${agentToken}`)
+        .send({
+          price: 6000000,
+          state: 'Nairobi',
+          city: 'Nairobi',
+          address: 'Kenya',
+          type: '2 bedroom',
+          image_url: 'kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
+        })
+        .end((err, res) => {
+          res.should.have.status(400);
+          expect(res.body.error).equals('"image_url" is not allowed');
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not update advert with missing price', (done) => {
+      chai.request(app)
+        .patch('/api/v2/property/1')
+        .set('authorization', `Bearer ${agentToken}`)
+        .send({
+          price: '',
+          state: 'Nairobi',
+          city: 'Nairobi',
+          address: 'Kenya',
+          type: '2 bedroom',
+          image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
+        })
+        .end((err, res) => {
+          res.should.have.status(400);
+          expect(res.body.error).equals('Price is a required field with no special chars or alphabets');
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not update advert with missing state', (done) => {
+      chai.request(app)
+        .patch('/api/v2/property/1')
+        .set('authorization', `Bearer ${agentToken}`)
+        .send({
+          price: 6000000,
+          state: '',
+          city: 'Nairobi',
+          address: 'Kenya',
+          type: '2 bedroom',
+          image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
+        })
+        .end((err, res) => {
+          res.should.have.status(400);
+          expect(res.body.error).equals('State is a required field with a min of 3 chars and no special chars');
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not update advert with missing city', (done) => {
+      chai.request(app)
+        .patch('/api/v2/property/1')
+        .set('authorization', `Bearer ${agentToken}`)
+        .send({
+          price: 6000000,
+          state: 'Nairobi',
+          city: '',
+          address: 'Kenya',
+          type: '2 bedroom',
+          image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
+        })
+        .end((err, res) => {
+          res.should.have.status(400);
+          expect(res.body.error).equals('City is a required field with a min of 3 chars and no special chars or numbers');
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not update advert with missing address', (done) => {
+      chai.request(app)
+        .patch('/api/v2/property/1')
+        .set('authorization', `Bearer ${agentToken}`)
+        .send({
+          price: 6000000,
+          state: 'Nairobi',
+          city: 'Nairobi',
+          address: '',
+          type: '2 bedroom',
+          image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
+        })
+        .end((err, res) => {
+          res.should.have.status(400);
+          expect(res.body.error).equals('Address is a required field with a min of 3 chars and no special chars or numbers');
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not update advert with missing type', (done) => {
+      chai.request(app)
+        .patch('/api/v2/property/1')
+        .set('authorization', `Bearer ${agentToken}`)
+        .send({
+          price: 6000000,
+          state: 'Nairobi',
+          city: 'Nairobi',
+          address: 'Kenya',
+          type: ' ',
+          image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
+        })
+        .end((err, res) => {
+          res.should.have.status(400);
+          expect(res.body.error).equals('Type is a required field with a min of 3 chars and no special characters');
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not update advert with missing image_url', (done) => {
+      chai.request(app)
+        .patch('/api/v2/property/1')
+        .set('authorization', `Bearer ${agentToken}`)
+        .send({
+          price: 6000000,
+          state: 'Nairobi',
+          city: 'Nairobi',
+          address: 'Kenya',
+          type: '2 bedroom',
+          image_url: '',
+        })
+        .end((err, res) => {
+          res.should.have.status(400);
+          expect(res.body.error).equals('"image_url" is not allowed');
+          if (err) return done();
+          done();
+        });
+    });
+  });
+
+  describe('/PATCH sold-property', () => {
+    it('should successfully mark property as sold', (done) => {
+      chai.request(app)
+        .patch('/api/v2/property/1/sold')
+        .set('authorization', `Bearer ${agentToken}`)
+        .end((err, res) => {
+          res.should.have.status(200);
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not mark a property advert with no token', (done) => {
+      chai.request(app)
+        .patch('/api/v2/property/1/sold')
+        .set('authorization', ' ')
+        .end((err, res) => {
+          res.should.have.status(401);
+          expect(res.body.error).equals('ACCESS DENIED! No token provided');
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not mark a property advert with forbidden token', (done) => {
+      chai.request(app)
+        .patch('/api/v2/property/1/sold')
+        .set('authorization', `Bearer ${userToken}`)
+        .end((err, res) => {
+          res.should.have.status(403);
+          expect(res.body.error).equals('ACCESS DENIED! Not an Agent');
+          if (err) return done();
+          done();
+        });
+    });
+
+    it('should not mark a property advert if no id exists', (done) => {
+      chai.request(app)
+        .patch('/api/v2/property/111/sold')
+        .set('authorization', `Bearer ${agentToken}`)
+        .end((err, res) => {
+          res.should.have.status(404);
+          expect(res.body.error).equals('You have no advert with that Id');
+          if (err) return done();
+          done();
+        });
+    });
+  });
 });
-//   describe('/PATCH property', () => {
-//     it('should successfully update property advert', (done) => {
-//       chai.request(app)
-//         .patch('/api/v2/property/1')
-//         .set('authorization', `Bearer ${agentToken}`)
-//         .send({
-//           price: 6000000,
-//           state: 'Nairobi',
-//           city: 'Nairobi',
-//           address: 'Kenya',
-//           type: '2 bedroom',
-//         })
-//         .end((err, res) => {
-//           res.should.have.status(200);
-//           if (err) return done();
-//           done();
-//         });
-//     });
-
-//     it('should not update a property advert with no token', (done) => {
-//       chai.request(app)
-//         .patch('/api/v2/property/1')
-//         .set('authorization', ' ')
-//         .send({
-//           price: 6000000,
-//           state: 'Nairobi',
-//           city: 'Nairobi',
-//           address: 'Kenya',
-//           type: '2 bedroom',
-//           image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
-//         })
-//         .end((err, res) => {
-//           res.should.have.status(401);
-//           expect(res.body.error).equals('ACCESS DENIED! No token provided');
-//           if (err) return done();
-//           done();
-//         });
-//     });
-
-//     it('should not update a property advert with forbidden token', (done) => {
-//       chai.request(app)
-//         .patch('/api/v2/property/1')
-//         .set('authorization', `Bearer ${userToken}`)
-//         .send({
-//           price: 6000000,
-//           state: 'Nairobi',
-//           city: 'Nairobi',
-//           address: 'Kenya',
-//           type: '2 bedroom',
-//           image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
-//         })
-//         .end((err, res) => {
-//           res.should.have.status(403);
-//           expect(res.body.error).equals('ACCESS DENIED! Not an Agent');
-//           if (err) return done();
-//           done();
-//         });
-//     });
-
-//     it('should not update a property advert if no id exists', (done) => {
-//       chai.request(app)
-//         .patch('/api/v2/property/111')
-//         .set('authorization', `Bearer ${agentToken}`)
-//         .send({
-//           price: 6000000,
-//           state: 'Nairobi',
-//           city: 'Nairobi',
-//           address: 'Kenya',
-//           type: '2 bedroom',
-//         })
-//         .end((err, res) => {
-//           res.should.have.status(404);
-//           expect(res.body.error).equals('You have no advert with that Id');
-//           if (err) return done();
-//           done();
-//         });
-//     });
-
-//     it('should not update advert with invalid price', (done) => {
-//       chai.request(app)
-//         .patch('/api/v2/property/1')
-//         .set('authorization', `Bearer ${agentToken}`)
-//         .send({
-//           price: 'yazaa',
-//           state: 'Nairobi',
-//           city: 'Nairobi',
-//           address: 'Kenya',
-//           type: '2 bedroom',
-//           image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
-//         })
-//         .end((err, res) => {
-//           res.should.have.status(400);
-//           expect(res.body.error).equals('Price is a required field with no special chars or alphabets');
-//           if (err) return done();
-//           done();
-//         });
-//     });
-
-//     it('should not update advert with invalid state', (done) => {
-//       chai.request(app)
-//         .patch('/api/v2/property/1')
-//         .set('authorization', `Bearer ${agentToken}`)
-//         .send({
-//           price: 6000000,
-//           state: 'Nai@robi',
-//           city: 'Nairobi',
-//           address: 'Kenya',
-//           type: '2 bedroom',
-//           image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
-//         })
-//         .end((err, res) => {
-//           res.should.have.status(400);
-//           expect(res.body.error).equals('State is a required field with a min of 3 chars and no special chars');
-//           if (err) return done();
-//           done();
-//         });
-//     });
-
-//     it('should not update advert with invalid city', (done) => {
-//       chai.request(app)
-//         .patch('/api/v2/property/1')
-//         .set('authorization', `Bearer ${agentToken}`)
-//         .send({
-//           price: 6000000,
-//           state: 'Nairobi',
-//           city: 'N@irobi',
-//           address: 'Kenya',
-//           type: '2 bedroom',
-//           image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
-//         })
-//         .end((err, res) => {
-//           res.should.have.status(400);
-//           expect(res.body.error).equals('City is a required field with a min of 3 chars and no special chars or numbers');
-//           if (err) return done();
-//           done();
-//         });
-//     });
-
-//     it('should not update advert with invalid address', (done) => {
-//       chai.request(app)
-//         .patch('/api/v2/property/1')
-//         .set('authorization', `Bearer ${agentToken}`)
-//         .send({
-//           price: 6000000,
-//           state: 'Nairobi',
-//           city: 'Nairobi',
-//           address: 'Keny@',
-//           type: '2 bedroom',
-//           image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
-//         })
-//         .end((err, res) => {
-//           res.should.have.status(400);
-//           expect(res.body.error).equals('Address is a required field with a min of 3 chars and no special chars or numbers');
-//           if (err) return done();
-//           done();
-//         });
-//     });
-
-//     it('should not update advert with invalid type', (done) => {
-//       chai.request(app)
-//         .patch('/api/v2/property/1')
-//         .set('authorization', `Bearer ${agentToken}`)
-//         .send({
-//           price: 6000000,
-//           state: 'Nairobi',
-//           city: 'Nairobi',
-//           address: 'Kenya',
-//           type: '1Rm',
-//           image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
-//         })
-//         .end((err, res) => {
-//           res.should.have.status(400);
-//           expect(res.body.error).equals('Type is a required field with a min of 3 chars and no special characters');
-//           if (err) return done();
-//           done();
-//         });
-//     });
-
-//     it('should not update advert with invalid image_url', (done) => {
-//       chai.request(app)
-//         .patch('/api/v2/property/1')
-//         .set('authorization', `Bearer ${agentToken}`)
-//         .send({
-//           price: 6000000,
-//           state: 'Nairobi',
-//           city: 'Nairobi',
-//           address: 'Kenya',
-//           type: '2 bedroom',
-//           image_url: 'kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
-//         })
-//         .end((err, res) => {
-//           res.should.have.status(400);
-//           expect(res.body.error).equals('"image_url" is not allowed');
-//           if (err) return done();
-//           done();
-//         });
-//     });
-
-//     it('should not update advert with missing price', (done) => {
-//       chai.request(app)
-//         .patch('/api/v2/property/1')
-//         .set('authorization', `Bearer ${agentToken}`)
-//         .send({
-//           price: '',
-//           state: 'Nairobi',
-//           city: 'Nairobi',
-//           address: 'Kenya',
-//           type: '2 bedroom',
-//           image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
-//         })
-//         .end((err, res) => {
-//           res.should.have.status(400);
-//           expect(res.body.error).equals('Price is a required field with no special chars or alphabets');
-//           if (err) return done();
-//           done();
-//         });
-//     });
-
-//     it('should not update advert with missing state', (done) => {
-//       chai.request(app)
-//         .patch('/api/v2/property/1')
-//         .set('authorization', `Bearer ${agentToken}`)
-//         .send({
-//           price: 6000000,
-//           state: '',
-//           city: 'Nairobi',
-//           address: 'Kenya',
-//           type: '2 bedroom',
-//           image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
-//         })
-//         .end((err, res) => {
-//           res.should.have.status(400);
-//           expect(res.body.error).equals('State is a required field with a min of 3 chars and no special chars');
-//           if (err) return done();
-//           done();
-//         });
-//     });
-
-//     it('should not update advert with missing city', (done) => {
-//       chai.request(app)
-//         .patch('/api/v2/property/1')
-//         .set('authorization', `Bearer ${agentToken}`)
-//         .send({
-//           price: 6000000,
-//           state: 'Nairobi',
-//           city: '',
-//           address: 'Kenya',
-//           type: '2 bedroom',
-//           image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
-//         })
-//         .end((err, res) => {
-//           res.should.have.status(400);
-//           expect(res.body.error).equals('City is a required field with a min of 3 chars and no special chars or numbers');
-//           if (err) return done();
-//           done();
-//         });
-//     });
-
-//     it('should not update advert with missing address', (done) => {
-//       chai.request(app)
-//         .patch('/api/v2/property/1')
-//         .set('authorization', `Bearer ${agentToken}`)
-//         .send({
-//           price: 6000000,
-//           state: 'Nairobi',
-//           city: 'Nairobi',
-//           address: '',
-//           type: '2 bedroom',
-//           image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
-//         })
-//         .end((err, res) => {
-//           res.should.have.status(400);
-//           expect(res.body.error).equals('Address is a required field with a min of 3 chars and no special chars or numbers');
-//           if (err) return done();
-//           done();
-//         });
-//     });
-
-//     it('should not update advert with missing type', (done) => {
-//       chai.request(app)
-//         .patch('/api/v2/property/1')
-//         .set('authorization', `Bearer ${agentToken}`)
-//         .send({
-//           price: 6000000,
-//           state: 'Nairobi',
-//           city: 'Nairobi',
-//           address: 'Kenya',
-//           type: ' ',
-//           image_url: 'https://kinsta.com/wp-content/uploads/2017/04/change-wordpress-url-1.png',
-//         })
-//         .end((err, res) => {
-//           res.should.have.status(400);
-//           expect(res.body.error).equals('Type is a required field with a min of 3 chars and no special characters');
-//           if (err) return done();
-//           done();
-//         });
-//     });
-
-//     it('should not update advert with missing image_url', (done) => {
-//       chai.request(app)
-//         .patch('/api/v2/property/1')
-//         .set('authorization', `Bearer ${agentToken}`)
-//         .send({
-//           price: 6000000,
-//           state: 'Nairobi',
-//           city: 'Nairobi',
-//           address: 'Kenya',
-//           type: '2 bedroom',
-//           image_url: '',
-//         })
-//         .end((err, res) => {
-//           res.should.have.status(400);
-//           expect(res.body.error).equals('"image_url" is not allowed');
-//           if (err) return done();
-//           done();
-//         });
-//     });
-//   });
-
-//   describe('/PATCH sold-property', () => {
-//     it('should successfully mark property as sold', (done) => {
-//       chai.request(app)
-//         .patch('/api/v2/property/1/sold')
-//         .set('authorization', `Bearer ${agentToken}`)
-//         .end((err, res) => {
-//           res.should.have.status(200);
-//           if (err) return done();
-//           done();
-//         });
-//     });
-
-//     it('should not mark a property advert with no token', (done) => {
-//       chai.request(app)
-//         .patch('/api/v2/property/1/sold')
-//         .set('authorization', ' ')
-//         .end((err, res) => {
-//           res.should.have.status(401);
-//           expect(res.body.error).equals('ACCESS DENIED! No token provided');
-//           if (err) return done();
-//           done();
-//         });
-//     });
-
-//     it('should not mark a property advert with forbidden token', (done) => {
-//       chai.request(app)
-//         .patch('/api/v2/property/1/sold')
-//         .set('authorization', `Bearer ${userToken}`)
-//         .end((err, res) => {
-//           res.should.have.status(403);
-//           expect(res.body.error).equals('ACCESS DENIED! Not an Agent');
-//           if (err) return done();
-//           done();
-//         });
-//     });
-
-//     it('should not mark a property advert if no id exists', (done) => {
-//       chai.request(app)
-//         .patch('/api/v2/property/111/sold')
-//         .set('authorization', `Bearer ${agentToken}`)
-//         .end((err, res) => {
-//           res.should.have.status(404);
-//           expect(res.body.error).equals('You have no advert with that Id');
-//           if (err) return done();
-//           done();
-//         });
-//     });
-//   });
 
 //   describe('/PATCH property fraudulent', () => {
 //     it('should mark property as fraudulent', (done) => {


### PR DESCRIPTION
#### What does this PR do?
Allows an Agent to mark a property advert as sold
#### Description of Task to be completed?
* This route should only be accessible for an agent with an authenticated token.
* The property details should be saved in a database
#### How should this be manually tested?
* Clone this  repository https://github.com/BurnerB/PropertyProLite-CH2.git and cd into Propertypro-ch2
* checkout to branch ft-agent-mark-advert-sold-db-167287845
* Run command `npm start` on your terminal
* Using [postman](https://www.getpostman.com/)
* Navigate to `PATCH:api/v1/property<:Property-id>/sold` t
* You should recieve a response with an advert status marked sold:
 ```
 "status": 200,
    "data": [
        {
            "id": 1,
            "owner": 1,
            "owneremail": "hezron123@gmail.com",
            "status": "SOLD",
            "type": "1 bedroom",
            "state": "Rwanda",
            "city": "Kigali",
            "price": "6000000",
            "address": "Kigali12345",
            "image_url": "http://res.cloudinary.com/burnerb/image/upload/v1563486052/y1qbvnztatpn1j3owzxc.png",
            "created_on": "2019-07-18T21:40:51.427Z"
        }
 ```

#### Any background context you want to provide?
This route is now configured to work with a database
#### What are the relevant pivotal tracker stories?
[#167287845](https://www.pivotaltracker.com/story/show/167287845)

#### Screenshots (if appropriate)