### PR TITLE
[#167287863] Agent delete advert 

### DIFF
--- a/server/controllers/propertyEndpoints.js
+++ b/server/controllers/propertyEndpoints.js
@@ -102,15 +102,13 @@ class Property {
 
       const user_id = decoded._id;
 
-      const _id = req.params.property_id;
+      const id = req.params.property_id;
 
-      const property = new PropertyModel({
-        _id,
-      });
+      const property = await PropertyModel.delete(id)
 
-      if (!await property.delete() || (user_id !== property.result.owner)) {
+      if ( !property|| (user_id !== property.owner)) {
         return response.handleError(404, 'You have no advert with that Id', res);
-      } return response.success(200, 'successfully deleted ', res);
+      }return response.success(200, 'successfully deleted ', res);
     } catch (e) {
       return response.catchError(500, e.toString(), res);
     }

--- a/server/models/propertyModel.js
+++ b/server/models/propertyModel.js
@@ -48,5 +48,12 @@ class PropertyModel {
     const { rows } = await pool.query(query,values)
     return rows;
   }
+
+  static async delete(id) {
+    const text = 'DELETE FROM properties WHERE id =$1';
+    const values = [id];
+    const { rows } = await pool.query(text, values);
+    return rows;
+}
 }
 export default PropertyModel;

--- a/server/tests/property.test.js
+++ b/server/tests/property.test.js
@@ -645,53 +645,54 @@ describe('/PROPERTY', () => {
         });
     });
   });
-describe('/PATCH sold-property', () => {
-    it('should successfully mark property as sold', (done) => {
-      chai.request(app)
-        .patch('/api/v2/property/1/sold')
-        .set('authorization', `Bearer ${agentToken}`)
-        .end((err, res) => {
-          res.should.have.status(200);
-          if (err) return done();
-          done();
-        });
-    });
 
-    it('should not mark a property advert with no token', (done) => {
-      chai.request(app)
-        .patch('/api/v2/property/1/sold')
-        .set('authorization', ' ')
-        .end((err, res) => {
-          res.should.have.status(401);
-          expect(res.body.error).equals('ACCESS DENIED! No token provided');
-          if (err) return done();
-          done();
-        });
-    });
+  describe('/PATCH sold-property', () => {
+      it('should successfully mark property as sold', (done) => {
+        chai.request(app)
+          .patch('/api/v2/property/1/sold')
+          .set('authorization', `Bearer ${agentToken}`)
+          .end((err, res) => {
+            res.should.have.status(200);
+            if (err) return done();
+            done();
+          });
+      });
 
-    it('should not mark a property advert with forbidden token', (done) => {
-      chai.request(app)
-        .patch('/api/v2/property/1/sold')
-        .set('authorization', `Bearer ${userToken}`)
-        .end((err, res) => {
-          res.should.have.status(403);
-          expect(res.body.error).equals('ACCESS DENIED! Not an Agent');
-          if (err) return done();
-          done();
-        });
-    });
+      it('should not mark a property advert with no token', (done) => {
+        chai.request(app)
+          .patch('/api/v2/property/1/sold')
+          .set('authorization', ' ')
+          .end((err, res) => {
+            res.should.have.status(401);
+            expect(res.body.error).equals('ACCESS DENIED! No token provided');
+            if (err) return done();
+            done();
+          });
+      });
 
-    it('should not mark a property advert if no id exists', (done) => {
-      chai.request(app)
-        .patch('/api/v2/property/111/sold')
-        .set('authorization', `Bearer ${agentToken}`)
-        .end((err, res) => {
-          res.should.have.status(404);
-          expect(res.body.error).equals('You have no advert with that Id');
-          if (err) return done();
-          done();
-        });
-    });
+      it('should not mark a property advert with forbidden token', (done) => {
+        chai.request(app)
+          .patch('/api/v2/property/1/sold')
+          .set('authorization', `Bearer ${userToken}`)
+          .end((err, res) => {
+            res.should.have.status(403);
+            expect(res.body.error).equals('ACCESS DENIED! Not an Agent');
+            if (err) return done();
+            done();
+          });
+      });
+
+      it('should not mark a property advert if no id exists', (done) => {
+        chai.request(app)
+          .patch('/api/v2/property/111/sold')
+          .set('authorization', `Bearer ${agentToken}`)
+          .end((err, res) => {
+            res.should.have.status(404);
+            expect(res.body.error).equals('You have no advert with that Id');
+            if (err) return done();
+            done();
+          });
+      });
   });
 });
 


### PR DESCRIPTION
#### What does this PR do?
Allows an Agent to delete their property advert
#### Description of Task to be completed?
* This route should only be accessible for an agent with an authenticated token.
* The property details should be saved in a database
#### How should this be manually tested?
* Clone this  repository https://github.com/BurnerB/PropertyProLite-CH2.git and cd into Propertypro-ch2
* checkout to branch ft-agent-delete-advert-db-167287863
* Run command `npm start` on your terminal
* Using [postman](https://www.getpostman.com/)
* Navigate to `DELETE /api/v2/property/<:Property-Id>` 
* You should recieve a response with an advert deleted:
 ```
 {
    "status": 200,
    "data": "successfully deleted "
}
 ```

#### Any background context you want to provide?
This route is now configured to work with a database
#### What are the relevant pivotal tracker stories?
[#167287863](https://www.pivotaltracker.com/story/show/167287863)
#### Screenshots (if appropriate)
![delete advet](https://user-images.githubusercontent.com/45785786/61499466-f5486e80-a9cf-11e9-8032-4097b60d4a94.png)
