### PR TITLE
[#167287899] User search properties by type

### DIFF
--- a/server/controllers/propertyEndpoints.js
+++ b/server/controllers/propertyEndpoints.js
@@ -116,11 +116,12 @@ class Property {
 
   static async allAdverts(req, res) {
     try {
-      const property = await PropertyModel.allproperties();
-      if (!property) {
+      const properties = await PropertyModel.allproperties();
+      console.log(properties);
+      if (!properties) {
         return response.handleError(404, 'No adverts found', res);
       }
-      return response.handleSuccess(200, property, res);
+      return response.handleSuccess(200, properties, res);
     } catch (e) {
       return response.catchError(500, e.toString(), res);
     }

--- a/server/controllers/propertyEndpoints.js
+++ b/server/controllers/propertyEndpoints.js
@@ -117,7 +117,6 @@ class Property {
   static async allAdverts(req, res) {
     try {
       const properties = await PropertyModel.allproperties();
-      console.log(properties);
       if (!properties) {
         return response.handleError(404, 'No adverts found', res);
       }
@@ -130,13 +129,13 @@ class Property {
   static async specificType(req, res) {
     try {
       const { type } = req.query;
-      const Type = new PropertyModel({ type });
+      const Type = await PropertyModel.searchbyType(type);
 
       // return res.send(req.query)
-      if (!await Type.searchbyType()) {
+      if (!Type) {
         return response.handleError(404, 'No property adverts of that type found', res);
       }
-      return response.handleSuccess(200, Type.result, res);
+      return response.handleSuccess(200, Type, res);
     } catch (e) {
       return response.catchError(500, e.toString(), res);
     }

--- a/server/models/propertyModel.js
+++ b/server/models/propertyModel.js
@@ -54,6 +54,13 @@ class PropertyModel {
     const values = [id];
     const { rows } = await pool.query(text, values);
     return rows;
-}
+  }
+
+  static async searchbyType(type) {
+    const { rows } = await pool.query('SELECT * FROM properties WHERE type=$1', [type]);
+    return rows;
+  }
+
+
 }
 export default PropertyModel;

--- a/server/models/propertyModel.js
+++ b/server/models/propertyModel.js
@@ -31,7 +31,7 @@ class PropertyModel {
   static async allproperties(){
     const query = `SELECT * FROM properties`;
     const adverts = await pool.query(query);
-    const allAdverts = adverts.rows[0];
+    const allAdverts = adverts.rows;
     return allAdverts;
   }
 

--- a/server/tests/property.test.js
+++ b/server/tests/property.test.js
@@ -694,7 +694,6 @@ describe('/PROPERTY', () => {
           });
       });
   });
-});
 
 //   describe('/PATCH property fraudulent', () => {
 //     it('should mark property as fraudulent', (done) => {
@@ -846,67 +845,66 @@ describe('/PROPERTY', () => {
 //     });
 //   });
   
-//   describe('/DELETE property', () => {
-//     it('should successfully delete a  property advert', (done) => {
-//       chai.request(app)
-//         .delete('/api/v2/property/1')
-//         .set('authorization', `Bearer ${agentToken}`)
-//         .end((err, res) => {
-//           res.should.have.status(200);
-//           if (err) return done();
-//           done();
-//         });
-//     });
+  describe('/DELETE property', () => {
+    it('should successfully delete a  property advert', (done) => {
+      chai.request(app)
+        .delete('/api/v2/property/1')
+        .set('authorization', `Bearer ${agentToken}`)
+        .end((err, res) => {
+          res.should.have.status(200);
+          if (err) return done();
+          done();
+        });
+    });
 
-//     it('should not delete property advert with no token', (done) => {
-//       chai.request(app)
-//         .delete('/api/v2/property/1')
-//         .set('authorization', ' ')
-//         .end((err, res) => {
-//           res.should.have.status(401);
-//           expect(res.body.error).equals('ACCESS DENIED! No token provided');
-//           if (err) return done();
-//           done();
-//         });
-//     });
+    it('should not delete property advert with no token', (done) => {
+      chai.request(app)
+        .delete('/api/v2/property/1')
+        .set('authorization', ' ')
+        .end((err, res) => {
+          res.should.have.status(401);
+          expect(res.body.error).equals('ACCESS DENIED! No token provided');
+          if (err) return done();
+          done();
+        });
+    });
 
-//     it('should not delete a property advert with forbidden token', (done) => {
-//       chai.request(app)
-//         .delete('/api/v2/property/1')
-//         .set('authorization', `Bearer ${userToken}`)
-//         .end((err, res) => {
-//           res.should.have.status(403);
-//           expect(res.body.error).equals('ACCESS DENIED! Not an Agent');
-//           if (err) return done();
-//           done();
-//         });
-//     });
+    it('should not delete a property advert with forbidden token', (done) => {
+      chai.request(app)
+        .delete('/api/v2/property/1')
+        .set('authorization', `Bearer ${userToken}`)
+        .end((err, res) => {
+          res.should.have.status(403);
+          expect(res.body.error).equals('ACCESS DENIED! Not an Agent');
+          if (err) return done();
+          done();
+        });
+    });
 
-//     it('should not delete a property advert if no id exists', (done) => {
-//       chai.request(app)
-//         .delete('/api/v2/property/1')
-//         .set('authorization', `Bearer ${agentToken}`)
-//         .end((err, res) => {
-//           expect(res.body.error).equals('You have no advert with that Id');
-//           res.should.have.status(404);
-//           if (err) return done();
-//           done();
-//         });
-//     });
-//   });
+    it('should not delete a property advert if no id exists', (done) => {
+      chai.request(app)
+        .delete('/api/v2/property/1')
+        .set('authorization', `Bearer ${agentToken}`)
+        .end((err, res) => {
+          expect(res.body.error).equals('You have no advert with that Id');
+          res.should.have.status(404);
+          if (err) return done();
+          done();
+        });
+    });
+  });
 
-//   describe('/GET all properties', () => {
-//     it('should return an error message if no adverts exist', (done) => {
-//       chai.request(app)
-//         .get('/api/v2/properties')
-//         .end((err, res) => {
-//           expect(res.body.error).equals('No adverts found');
-//           res.should.have.status(404);
-//           if (err) return done();
-//           done();
-//         });
-//     });
-//   });
-
+  describe('/GET all properties', () => {
+    it('should return an error message if no adverts exist', (done) => {
+      chai.request(app)
+        .get('/api/v2/properties')
+        .end((err, res) => {
+          expect(res.body.error).equals('No adverts found');
+          res.should.have.status(404);
+          if (err) return done();
+          done();
+        });
+    });
+  });
   
-// });
+});


### PR DESCRIPTION
#### What does this PR do?
Allows User to get specific property advert types
#### Description of Task to be completed?
* This route should only be accessible for an agent with an authenticated token.
* The property details should be saved in a database
#### How should this be manually tested?
* Clone this  repository https://github.com/BurnerB/PropertyProLite-CH2.git and cd into Propertypro-ch2
* checkout to branch ft-user-get-properties-167287899
* Run command `npm start` on your terminal
* Using [postman](https://www.getpostman.com/)
* Navigate to `GET api/v1/property/<:Property-Id>` 
* You should recieve a response with an adverts with similar types
 
#### Any background context you want to provide?
This route is now configured to work with a database
#### What are the relevant pivotal tracker stories?
[#167287899](https://www.pivotaltracker.com/story/show/167287899)
#### Screenshots (if appropriate)
![SPECIFIC PROPERTY](https://user-images.githubusercontent.com/45785786/61501325-8d962180-a9d7-11e9-9ba1-8d2571a054be.png)
